### PR TITLE
F/responsive list

### DIFF
--- a/client/src/components/list/RenderList.js
+++ b/client/src/components/list/RenderList.js
@@ -31,5 +31,11 @@ export default function RenderList({ list }) {
       </article>
     );
   });
+  lists.push(
+    <span
+      key="fffffffffffffffffffffffg"
+      className="inline-block overflow-hidden h-90 w-80 md:w-96 cursor-pointer m-3"
+    />,
+  );
   return lists;
 }

--- a/client/src/components/list/RescueList.js
+++ b/client/src/components/list/RescueList.js
@@ -99,7 +99,7 @@ function RescueList() {
           </div>
         </div>
 
-        <main className="w-screen mx-auto my-0 text-[0px]">
+        <main className="inline-flex flex-wrap justify-center p-5 w-screen mx-auto my-0 text-[0px]">
           <RenderList list={rescueList} />
         </main>
         <Pagination


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/20448972/184297656-eab1a32f-5155-49a6-afe3-7ff5ad648505.png)

이슈 : 리스트 전체 main tag 는 중앙정렬하지만 리스트 내부 article tag는 왼쪽 정렬을 원하는 것으로 판단.
해결 : article 수는 홀수. 마지막 row가 중앙정렬되지 못하도록 비어있는 span 1개가 col이 홀수일때 아래에 찌그러져 있다가 col이 짝수일때 article 차이 1개 만큼 자리 차지.

기존 ) 
![image](https://user-images.githubusercontent.com/20448972/184299336-97320213-30ed-4789-b38a-495a08fb173c.png)
또는 
![image](https://user-images.githubusercontent.com/20448972/184299383-ea08180a-bb0c-4b1b-a5ce-d9b216a610ce.png)

===================================================================

결과)

case 1 : col = 4
![image](https://user-images.githubusercontent.com/20448972/184298022-f2082de1-ef1d-43d8-be00-7df063480324.png)

case 2 : col = 3
![image](https://user-images.githubusercontent.com/20448972/184298166-f07b6ff5-260c-4639-9474-f0fcceb5d153.png)

case 3 : col = 2
![image](https://user-images.githubusercontent.com/20448972/184298235-9f36a0ba-52df-49e2-83bf-ca7fbbb583c0.png)

hint ref : https://stackoverflow.com/questions/16375009/center-multiple-inline-blocks-with-css-and-align-the-last-row-to-the-left

다른 방법 ref : https://stackoverflow.com/questions/19527104/left-aligned-last-row-in-centered-grid-of-elements
다른 방법으로는 2가지가 있는데 특정 크기에 대한 미디어쿼리 지정을 따로 해야해서 뭔가 찝찝한 방법