### PR TITLE
🔒️ kakao secure warning

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -16,7 +16,7 @@
     <link rel="/manifest" href="%PUBLIC_URL%/manifest.json" />
     <script
       type="text/javascript"
-      src="//dapi.kakao.com/v2/maps/sdk.js?appkey=%REACT_APP_KAKAO_API_KEY%&libraries=services,clusterer,drawing"
+      src="//dapi.kakao.com/v2/maps/sdk.js?appkey=%REACT_APP_KAKAO_API_JS_KEY%&libraries=services,clusterer,drawing"
     ></script>
     <meta name="google" value="notranslate" />
     <title>구해줘 댕냥쓰</title>

--- a/client/src/components/lost/FindPlaceName.js
+++ b/client/src/components/lost/FindPlaceName.js
@@ -12,7 +12,7 @@ function FindPlaceName({ position, setAddressName }) {
         method: 'GET',
         headers: {
           Host: 'dapi.kakao.com',
-          Authorization: 'KakaoAK 9af9de6fad57bca234b42bb02bcc14a2',
+          Authorization: `KakaoAK ${process.env.REACT_APP_KAKAO_API_REST_KEY}`,
         },
       },
     ).then((res) => {


### PR DESCRIPTION
실종 등록시 위경도 좌표-> 주소로 바꿀때 쓰는 카카오 지도 api에 키값을 env에 넣지 않고 바로 쓰고 있어서 수정하였습니다. env는 추후 디스코드로 공유드리도록 하겠습니다.