### PR TITLE
F/edit maps UI - 자잘한 지도 UI 수정

### DIFF
--- a/client/src/components/lost/LostPostMap.js
+++ b/client/src/components/lost/LostPostMap.js
@@ -151,6 +151,7 @@ function FindLocation({ setAddress, setAddressName, setRadius }) {
                 height: 40,
               },
             }}
+            clickable={false}
           />
         )}
       </Map>

--- a/client/src/components/map/MapView.js
+++ b/client/src/components/map/MapView.js
@@ -71,14 +71,8 @@ function EventMarkerContainer({ position, content, careCode, onMarkerClick }) {
       image={{
         src: 'https://i.ibb.co/MsqtRCN/pin.png',
         size: {
-          width: 64,
-          height: 69,
-        },
-        options: {
-          offset: {
-            x: 27,
-            y: 69,
-          },
+          width: 50,
+          height: 50,
         },
       }}
     >

--- a/client/src/components/map/MapView.js
+++ b/client/src/components/map/MapView.js
@@ -179,7 +179,7 @@ function MapView() {
           <Map // 지도를 표시할 Container
             center={state.center}
             className="w-full h-[85vh]"
-            level={3} // 지도의 확대 레벨
+            level={9} // 지도의 확대 레벨
           >
             {!state.isLoading && (
               <MapMarker

--- a/client/src/components/map/MapView.js
+++ b/client/src/components/map/MapView.js
@@ -188,16 +188,17 @@ function MapView() {
             level={3} // 지도의 확대 레벨
           >
             {!state.isLoading && (
-              <MapMarker 
+              <MapMarker
                 position={state.center}
                 image={{
-                src: 'https://i.ibb.co/F4q5WKP/image.png',
-                size: {
-                  width: 50,
-                  height: 50,
-                },
-              }}
-            />
+                  src: 'https://i.ibb.co/F4q5WKP/image.png',
+                  size: {
+                    width: 50,
+                    height: 50,
+                  },
+                }}
+                clickable={false}
+              />
             )}
             {shelterList.map((shelter) => (
               <div key={shelter.careCode}>


### PR DESCRIPTION
- 변경 사항
1. 메인지도, 분실등록지도 GPS 현재위치 아이콘 클릭 안되도록 수정
2. 메인지도 핀 불필요 오프셋 제거
3. 메인지도 핀 크기 축소 
4. 메인지도 맵 확대축소 초기 레벨 광범위하게 수정

- 결과
![image](https://user-images.githubusercontent.com/20448972/188556794-f8d00dcc-9af4-4a9e-b97e-2c8852ffe283.png)
